### PR TITLE
adding cors to registry

### DIFF
--- a/features/registry.go
+++ b/features/registry.go
@@ -20,6 +20,7 @@ var Registry = Middlewares{
 	{"ipfilter", "github.com/pyed/ipfilter", "Block or allow clients based on IP origin."},
 	{"search", "github.com/pedronasser/caddy-search", "Activates a site search engine"},
 	{"header", "", ""},
+	{"cors", "github.com/captncraig/cors/caddy", "Enable Cross Origin Resource Sharing"},
 	{"rewrite", "", ""},
 	{"redir", "", ""},
 	{"ext", "", ""},


### PR DESCRIPTION
Adding right after header because that seemed logical. It will generally not change code paths, so it could really go anywhere. 

Only possible impact is that it will return 200 without calling Next on valid preflight (OPTIONS) requests. nothing else will write to response or affect control flow.