### PR TITLE
Add multipass plugin to registry

### DIFF
--- a/features/registry.go
+++ b/features/registry.go
@@ -94,6 +94,13 @@ var Registry = Plugins{
 	},
 	{
 		Type:        DirectivePlugin,
+		Name:        "multipass",
+		Import:      "github.com/namsral/multipass/caddy",
+		Description: "Authorization by email",
+		DocsURL:     "/docs/multipass",
+	},
+	{
+		Type:        DirectivePlugin,
 		Name:        "jsonp",
 		Import:      "github.com/pschlump/caddy-jsonp",
 		Description: "Wrap JSON responses as JSONP",


### PR DESCRIPTION
This adds the multipass plugin to the Caddy Registry.

Relates to: https://github.com/caddyserver/caddyserver.com/pull/67