### PR TITLE
Add DNS server type

### DIFF
--- a/features/registry.go
+++ b/features/registry.go
@@ -33,6 +33,12 @@ var Registry = Plugins{
 		Description: "HTTP server core; everything most sites need",
 		Required:    true,
 	},
+	{
+		Type:        ServerPlugin,
+		Name:        "DNS",
+		Import:      "github.com/miekg/coredns/core",
+		Description: "DNS server core (see https://coredns.io)",
+	},
 
 	// Directives
 	{


### PR DESCRIPTION
This makes it possible for Caddy users to get Caddy with an easy-to-use DNS server!

@miekg, I need you to approve this in the comments before I merge it, basically shows that you have read and agree to this stuff: https://github.com/mholt/caddy/wiki/Publishing-a-Plugin-to-the-Download-Page