### PR TITLE
Update build.go

### DIFF
--- a/server/build.go
+++ b/server/build.go
@@ -72,9 +72,9 @@ func (b *Build) Build() error {
 		b.OutputFile,
 	}
 	if b.DownloadFileCompression == CompressZip {
-		err = archiver.Zip(b.DownloadFile, fileList)
+		err = archiver.Zip.Make(b.DownloadFile, fileList)
 	} else if b.DownloadFileCompression == CompressTarGz {
-		err = archiver.TarGz(b.DownloadFile, fileList)
+		err = archiver.TarGz.Make(b.DownloadFile, fileList)
 	} else {
 		return fmt.Errorf("unknown compress type %v", b.DownloadFileCompression)
 	}


### PR DESCRIPTION
Eliminate build error:

```
go get github.com/caddyserver/buildsrv
# github.com/caddyserver/buildsrv/server
../../caddyserver/buildsrv/server/build.go:75: cannot call non-function archiver.Zip (type archiver.zipFormat)
../../caddyserver/buildsrv/server/build.go:77: cannot call non-function archiver.TarGz (type archiver.tarGzFormat)
```